### PR TITLE
feat: add TS media file type support

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node"/>
-import {Readable as ReadableStream} from 'stream';
-import {ITokenizer} from 'strtok3/lib/core';
+import { Readable as ReadableStream } from 'stream';
+import { ITokenizer } from 'strtok3/lib/core';
 
 declare namespace core {
 	type FileExtension =
@@ -142,7 +142,8 @@ declare namespace core {
 		| 'zst'
 		| 'jxl'
 		| 'ntf'
-		| 'vcf';
+		| 'vcf'
+		| 'ts';
 
 	type MimeType =
 		| 'image/jpeg'
@@ -278,7 +279,8 @@ declare namespace core {
 		| 'model/3mf'
 		| 'image/jxl'
 		| 'application/vnd.nitf'
-		| 'application/zstd';
+		| 'application/zstd'
+		| 'video/mp2t';
 
 	interface FileTypeResult {
 		/**

--- a/core.js
+++ b/core.js
@@ -78,6 +78,15 @@ async function _fromTokenizer(tokenizer) {
 
 	await tokenizer.peekBuffer(buffer, {length: bytesRead, mayBeLess: true});
 
+	// -- 1-byte signatures
+
+	if (check([0x47])) {
+		return {
+			ext: 'ts',
+			mime: 'video/mp2t'
+		};
+	}
+
 	// -- 2-byte signatures --
 
 	if (check([0x42, 0x4D])) {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
 		"ntf",
 		"nitf",
 		"jxl",
-		"vcf"
+		"vcf",
+		"ts"
 	],
 	"devDependencies": {
 		"@types/node": "^13.1.4",

--- a/supported.js
+++ b/supported.js
@@ -141,7 +141,8 @@ module.exports = {
 		'jxl',
 		'ntf',
 		'nitf',
-		'vcf'
+		'vcf',
+		'ts'
 	],
 	mimeTypes: [
 		'image/jpeg',
@@ -277,6 +278,7 @@ module.exports = {
 		'model/3mf',
 		'image/jxl',
 		'application/vnd.nitf',
-		'application/zstd'
+		'application/zstd',
+		'video/mp2t'
 	]
 };


### PR DESCRIPTION
If you're adding support for a new file type, please follow the below steps:

- **One PR per file type.**
- Add a fixture file named `fixture.<extension>` to the `fixture` directory.
- Add the file extension to the `extensions` array in `supported.js`.
- Add the file's MIME type to the `types` array in `supported.js`.
- Add the file type detection logic to the `core.js` file.
- Add the file extension to the `FileType` type in `core.d.ts`.
- Add the file's MIME type to the `MimeType` type in `core.d.ts`.
- Add the file extension to the `Supported file types` section in the readme, in the format ```- [`<extension>`](URL) - Format name```, for example, ```- [`png`](https://en.wikipedia.org/wiki/Portable_Network_Graphics) - Portable Network Graphics```
- Add the file extension to the `keywords` array in the `package.json` file.
- Run `$ npm test` to ensure the tests pass.
- Open a pull request with a title like `Add support for Format`, for example, `Add support for PNG`.
- The pull request description should include a link to the official page of the file format or some other source. Also include a link to where you found the file type detection / magic bytes and the MIME type.
